### PR TITLE
fix mismatched square brackets in the usage section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ periodic intervals. A configuration might look something like this:
 ```edn
 {:duct.scheduler/simple
  {:jobs [{:interval 60   :run #ig/ref :example.job/every-minute}
-         {:interval 3600 :run #ig/ref :example.job/every-hour]}
+         {:interval 3600 :run #ig/ref :example.job/every-hour}]
 
  :example.job/every-minute {}
  :example.job/every-hour   {}}


### PR DESCRIPTION
the square brackets are mismatched in the  usage section of README,  at  :example.job/every-hour]}